### PR TITLE
Change run on windows using built-in package

### DIFF
--- a/example/http/cmd/server/main.go
+++ b/example/http/cmd/server/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT, syscall.SIGUSR2)
+	signal.Notify(sig, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGINT)
 	r := _router.Init()
 	go r.Run()
 	select {

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -1,12 +1,10 @@
 package server
 
 import (
-	"fmt"
 	"log"
 	nethttp "net/http"
 	"time"
 
-	_grace "github.com/facebookgo/grace/gracehttp"
 	_router "github.com/julienschmidt/httprouter"
 	_cors "github.com/rs/cors"
 )
@@ -72,11 +70,7 @@ func New(opts *Opts) *HTTP {
 // Run the server. Blocking. Execute it inside goroutine.
 func (http *HTTP) Run() {
 	// TODO add SO_REUSEPORT support
-	http.errChan <- _grace.Serve(&nethttp.Server{
-		Addr:        fmt.Sprintf(":%d", http.port),
-		Handler:     http.cors.Handler(http.handlers),
-		IdleTimeout: http.idleTimeout,
-	})
+	http.errChan <- http.serve()
 }
 
 func (http *HTTP) ListenError() <-chan error {

--- a/http/server/server_unix.go
+++ b/http/server/server_unix.go
@@ -1,0 +1,18 @@
+// +build darwin linux freebsd openbsd netbsd
+
+package server
+
+import (
+	"fmt"
+	nethttp "net/http"
+
+	_grace "github.com/facebookgo/grace/gracehttp"
+)
+
+func (http *HTTP) serve() error {
+	return _grace.Serve(&nethttp.Server{
+		Addr:        fmt.Sprintf(":%d", http.port),
+		Handler:     http.cors.Handler(http.handlers),
+		IdleTimeout: http.idleTimeout,
+	})
+}

--- a/http/server/server_windows.go
+++ b/http/server/server_windows.go
@@ -1,0 +1,22 @@
+// +build windows
+
+package server
+
+import (
+	"fmt"
+	nethttp "net/http"
+
+	_ "github.com/valyala/fasthttp/reuseport"
+)
+
+// graceful is not support in Windows. Using built-in package instead. This is for avoiding this package failed to run locally, rarely Windows used in server now.
+func (http *HTTP) serve() error {
+	srv := &nethttp.Server{
+		Addr:        fmt.Sprintf(":%d", http.port),
+		Handler:     http.cors.Handler(http.handlers),
+		IdleTimeout: http.idleTimeout,
+	}
+
+	// TODO add support for tls
+	return srv.ListenAndServe()
+}


### PR DESCRIPTION
Some os native signals are not supported in Windows, so adding built-in package for running on Windows would be nice, for the sake avoiding failed running on local Windows.